### PR TITLE
Added Architecture to AMI filter

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -60,6 +60,11 @@ data "aws_ami" "this" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
 }
 
 data "aws_security_group" "this_private" {


### PR DESCRIPTION
I'm working through the FEM course and noticed it fails to deploy the cluster auto scale group.

Error
```
api error ValidationError: You must use a valid fully-formed launch template. The architecture 'x86_64' of the specified instance type does not match the architecture 'arm64' of the specified AMI. Specify an instance type and an AMI that have matching architectures, and try again. You can use 'describe-instance-types' or 'describe-images' to discover the architecture of the instance type or AMI.
```

After some googling and trouble shooting I found the issue.

When filtering the AMI, it finds one that is 'arm64'. 

Adding a filter for architecture = `x86_64` fixes the issue. 


I wanted to add the fix for anyone else who runs into the same issue. This should also be updated in the branches for future folks.